### PR TITLE
Build and release new ingress-inquisition artifacts

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -1,0 +1,27 @@
+name: Build
+description: 'Run a script to build the project'
+inputs:
+  APP:
+    description: 'The app to build'
+    required: true
+  GO_VERSION:
+    description: 'The Go version to use'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    - name: Setup Go
+      uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+      with:
+        go-version: ${{ inputs.GO_VERSION }}
+    - name: Build
+      shell: bash
+      run: ./script/build.sh ${{ inputs.APP }}
+
+    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      with:
+        path: ${{ inputs.APP }}/release/**/${{ inputs.APP }}_*
+        name: artifact-${{ inputs.APP }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,6 @@
 name: ci
 
 env:
-  APP: bucket-blocker
   GO_VERSION: 1.22.1
 
 on:
@@ -34,34 +33,24 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Setup Go
-        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+      - name: Run build
+        uses: ./.github/actions/build
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - name: Build
-        run: ./script/build.sh bucket-blocker
+          APP: bucket-blocker
+          GO_VERSION: ${{ env.GO_VERSION }}
 
-      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        with:
-          path: bucket-blocker/release/**/${{ env.APP }}_*
-
-  build-ingress-inquisiton:
+  build-ingress-inquisition:
     name: Build ingress-inquisition
     needs: [test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Setup Go
-        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+      - name: Run build
+        uses: ./.github/actions/build
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - name: Build
-        run: ./script/build.sh ingress-inquisition
-
-      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        with:
-          path: ingress-inquisition/release/**/${{ env.APP }}_*
+          APP: ingress-inquisition
+          GO_VERSION: ${{ env.GO_VERSION }}
 
   enforce-dashes:
     name: Enforce bucket-blocker spelling
@@ -98,7 +87,7 @@ jobs:
       - name: Fetch build
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          name: artifact
+          name: artifact-bucket-blocker
           path: bucket-blocker/release
 
       - name: Release
@@ -112,7 +101,7 @@ jobs:
       contents: write
       packages: write
       issues: write
-    needs: [build-ingress-inquisiton]
+    needs: [build-ingress-inquisition]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
@@ -131,8 +120,8 @@ jobs:
       - name: Fetch build
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          name: artifact
-          path: ingress-inquisito/release
+          name: artifact-ingress-inquisition
+          path: ingress-inquisition/release
 
       - name: Release
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,14 +62,13 @@ jobs:
       - name: Lint naming
         run: ./bucket-blocker/script/dash-lint.sh
 
-  release-bucket-blocker:
+  release:
     name: Release
     permissions:
       contents: write
       packages: write
       issues: write
-    needs: [build-bucket-blocker, enforce-dashes]
-    if: github.ref == 'refs/heads/main'
+    needs: [build-ingress-inquisition, build-bucket-blocker, enforce-dashes]
     runs-on: ubuntu-latest
 
     steps:
@@ -89,33 +88,6 @@ jobs:
         with:
           name: artifact-bucket-blocker
           path: bucket-blocker/release
-
-      - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
-
-  release-ingress-inquisition:
-    name: Release
-    permissions:
-      contents: write
-      packages: write
-      issues: write
-    needs: [build-ingress-inquisition]
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
-        with:
-          # See https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md
-          node-version: "20.14.0"
 
       - name: Fetch build
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,9 @@ jobs:
       - name: Run tests
         run: go list -f '{{.Dir}}/...' -m | xargs go test
 
-  build:
-    name: Build
+  build-bucket-blocker:
+    name: Build bucket-blocker
+    needs: [test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -38,11 +39,29 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Build
-        run: ./bucket-blocker/script/build.sh
+        run: ./script/build.sh bucket-blocker
 
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           path: bucket-blocker/release/**/${{ env.APP }}_*
+
+  build-ingress-inquisiton:
+    name: Build ingress-inquisition
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Setup Go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Build
+        run: ./script/build.sh ingress-inquisition
+
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          path: ingress-inquisition/release/**/${{ env.APP }}_*
 
   enforce-dashes:
     name: Enforce bucket-blocker spelling
@@ -54,13 +73,13 @@ jobs:
       - name: Lint naming
         run: ./bucket-blocker/script/dash-lint.sh
 
-  release:
+  release-bucket-blocker:
     name: Release
     permissions:
       contents: write
       packages: write
       issues: write
-    needs: [test, build, enforce-dashes]
+    needs: [build-bucket-blocker, enforce-dashes]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
@@ -81,6 +100,39 @@ jobs:
         with:
           name: artifact
           path: bucket-blocker/release
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release
+
+  release-ingress-inquisition:
+    name: Release
+    permissions:
+      contents: write
+      packages: write
+      issues: write
+    needs: [build-ingress-inquisiton]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          # See https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md
+          node-version: "20.14.0"
+
+      - name: Fetch build
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: artifact
+          path: ingress-inquisito/release
 
       - name: Release
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,12 +8,20 @@
       {
         "assets": [
           {
-            "path": "release/darwin-amd64/bucket-blocker_darwin-amd64.tar.gz",
-            "label": "darwin-amd64"
+            "path": "bucket-blocker/release/darwin-amd64/bucket-blocker_darwin-amd64.tar.gz",
+            "label": "bucket-blocker_darwin-amd64"
           },
           {
-            "path": "release/darwin-arm64/bucket-blocker_darwin-arm64.tar.gz",
-            "label": "darwin-arm64"
+            "path": "bucket-blocker/release/darwin-arm64/bucket-blocker_darwin-arm64.tar.gz",
+            "label": "bucket-blocker_darwin-arm64"
+          },
+          {
+            "path": "ingress-inquisition/release/darwin-amd64/ingress-inquisition_darwin-amd64.tar.gz",
+            "label": "ingress-inquisition_darwin-amd64"
+          },
+          {
+            "path": "ingress-inquisition/release/darwin-arm64/ingress-inquisition_darwin-arm64.tar.gz",
+            "label": "ingress-inquisition_darwin-arm64"
           }
         ]
       }

--- a/script/build.sh
+++ b/script/build.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+APP=$1 # ie bucket-blocker or ingress-inquisition
+
 pushd () {
     command pushd "$@" > /dev/null
 }
@@ -11,9 +13,9 @@ popd () {
 }
 
 SCRIPT_PATH=$( cd "$(dirname "$0")" ; pwd -P )
-pushd "$SCRIPT_PATH/.."
+pushd "$SCRIPT_PATH/../$APP"
 
-APP=bucket-blocker
+
 
 # We only build for Mac OS
 ARCHITECTURES=("arm64" "amd64")


### PR DESCRIPTION
## What does this change?

- Generalise bucket-blocker's build script so that it also works for ingress-inquisition
- Create a reusable workflow for building and uploading artifacts, use it to build both tools
- Modify the release steps to reflect the new ingress-inquisition artifacts

## How to test

To test, I allowed releases to be run from non-main branches, and ran the full action. You can see the output [here](https://github.com/guardian/fsbp-tools/actions/runs/10485646173).

This generated [v2.1.0](https://github.com/guardian/fsbp-tools/releases/tag/v2.1.0), which i will remove the pre-release tag from on merge.