### PR TITLE
ci: clarify release step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
         run: ./bucket-blocker/script/dash-lint.sh
 
   release:
-    name: Release
+    name: Create GitHub release
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Having a step called `Release` could imply to new contributors/maintainers who only skimmed the readme that running this step is all that is required to create a new release on brew, which is not the case. Now we are being clear about exactly what this step is doing

## How can we measure success?

Less dev confusion
