### PR TITLE
fix: Skip user confirmation and execution if there are no security group rules to delete

### DIFF
--- a/ingress-inquisition/main.go
+++ b/ingress-inquisition/main.go
@@ -28,12 +28,12 @@ func main() {
 	securityGroupRuleDetails, err := utils.FindUnusedSecurityGroupRules(ctx, ec2Client, securityHubClient)
 	if err != nil {
 		log.Fatalf("Error finding unused security group rules: %v", err)
-	}
+	} else if len(securityGroupRuleDetails) == 0 {
+		fmt.Println("No unused security groups found")
+	} else if args.Execute {
 
-	fmt.Println("\n ")
-
-	var failures int = 0
-	if args.Execute && len(securityGroupRuleDetails) > 0 {
+		fmt.Println("\n ")
+		var failures int = 0
 		userConfirmed := common.UserConfirmation()
 		if userConfirmed {
 			log.Println("Starting to delete rules...")
@@ -47,10 +47,11 @@ func main() {
 
 			}
 		}
-	}
 
-	if failures > 0 {
-		log.Fatalf("Failed to delete %d rules", failures)
+		log.Printf("Finished deleting rules.")
+		if failures > 0 {
+			log.Fatalf("Failed to delete %d rules", failures)
+		}
 	}
 
 }

--- a/ingress-inquisition/main.go
+++ b/ingress-inquisition/main.go
@@ -33,7 +33,7 @@ func main() {
 	fmt.Println("\n ")
 
 	var failures int = 0
-	if args.Execute {
+	if args.Execute && len(securityGroupRuleDetails) > 0 {
 		userConfirmed := common.UserConfirmation()
 		if userConfirmed {
 			log.Println("Starting to delete rules...")

--- a/ingress-inquisition/utils/awsutils.go
+++ b/ingress-inquisition/utils/awsutils.go
@@ -152,16 +152,17 @@ func FindUnusedSecurityGroupRules(ctx context.Context, ec2Client *ec2.Client, se
 	if err != nil {
 		return nil, err
 	}
-	if len(unusedSecurityGroups) > 0 {
-		securityGroupRuleDetails := []SecurityGroupRuleDetails{}
+	securityGroupRuleDetails := []SecurityGroupRuleDetails{}
 
-		for _, sg := range unusedSecurityGroups {
-			rules, err := getSecurityGroupRuleDetails(ctx, ec2Client, sg)
-			if err != nil {
-				return nil, err
-			}
-			securityGroupRuleDetails = append(securityGroupRuleDetails, rules...)
+	for _, sg := range unusedSecurityGroups {
+		rules, err := getSecurityGroupRuleDetails(ctx, ec2Client, sg)
+		if err != nil {
+			return nil, err
 		}
+		securityGroupRuleDetails = append(securityGroupRuleDetails, rules...)
+	}
+
+	if len(securityGroupRuleDetails) > 0 {
 
 		fmt.Println("Ingress/egress rules on unused default security groups:")
 
@@ -173,16 +174,13 @@ func FindUnusedSecurityGroupRules(ctx context.Context, ec2Client *ec2.Client, se
 		}
 
 		err = w.Flush()
-
-		if err != nil {
-			return nil, err
-		}
-
-		return securityGroupRuleDetails, nil
-	} else {
-		fmt.Println("No unused security groups found")
-		return nil, nil
 	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return securityGroupRuleDetails, nil
 }
 
 func DeleteSecurityGroupRule(ctx context.Context, ec2Client *ec2.Client, rule SecurityGroupRuleDetails) error {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Previously, ingress-inquisition would always prompt for user permission to delete security group rules, even if there were none to delete. This is confusing behaviour. Now, if there are no rules to delete, the program simply prints `No unused security groups found` and exits.

I also moved some logs around.

This PR is much easier to review in [unified view, with whitespace off](https://github.com/guardian/fsbp-tools/pull/37/files?diff=unified&w=1), as most of the changes are moving things in and out of if/else blocks

## How to test

Run the program against the Deploy Tools account, which has no instances of this rule being broken

## How can we measure success?

Less confusing user experience
