### PR TITLE
fix: fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: artifact-fsbp-fix
-          path: fsbp-fix/release
+          path: release
 
       - name: Release
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,20 +8,12 @@
       {
         "assets": [
           {
-            "path": "bucket-blocker/release/darwin-amd64/bucket-blocker_darwin-amd64.tar.gz",
-            "label": "bucket-blocker_darwin-amd64"
+            "path": "release/darwin-amd64/fsbp-fix_darwin-amd64.tar.gz",
+            "label": "fsbp-fix_darwin-amd64"
           },
           {
-            "path": "bucket-blocker/release/darwin-arm64/bucket-blocker_darwin-arm64.tar.gz",
-            "label": "bucket-blocker_darwin-arm64"
-          },
-          {
-            "path": "ingress-inquisition/release/darwin-amd64/ingress-inquisition_darwin-amd64.tar.gz",
-            "label": "ingress-inquisition_darwin-amd64"
-          },
-          {
-            "path": "ingress-inquisition/release/darwin-arm64/ingress-inquisition_darwin-arm64.tar.gz",
-            "label": "ingress-inquisition_darwin-arm64"
+            "path": "release/darwin-arm64/fsbp-fix_darwin-arm64.tar.gz",
+            "label": "fsbp-fix_darwin-arm64"
           }
         ]
       }


### PR DESCRIPTION
Co-authored-by: @tjsilver 

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the release config to point only to fsbp-fix tools

## How to test

We verified this by creating a pre release with the correct artifacts attached to it

## How can we measure success?

We can release the tool