### PR TITLE
fix: make complement log less go-specific

### DIFF
--- a/common/math.go
+++ b/common/math.go
@@ -18,10 +18,10 @@ func Complement[T comparable](slice []T, toRemove []T) []T {
 		if !found {
 			complement = append(complement, element)
 		} else {
-			fmt.Printf("\nRemoving: '%v' from slice", element)
+			fmt.Printf("\nExcluding: '%v'", element)
 		}
 	}
-	fmt.Println("") //Tidy up the log output
+	fmt.Println("") //This ensures sure the log output is tidy
 
 	return complement
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

When calculating the complement of two slices, previously we would print `Removing <ELEMENT> from slice`. The term 'slice' is go specific, and wont make sense to general users of the tool. Let's remove the reference to language-specific features, and focus on what's actually happening to the element.

## How to test

This is just a logging change. CI passing should be sufficient