### PR TITLE
Check for a couple more erroneous delimiters at CI time

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ command from the bucket-blocker subdirectory, without needing to build the binar
 ```bash
 go run main.go S3.8 -profile <PROFILE> -region <REGION> [OPTIONAL_FLAGS]
 ```
+
 </details>
 
 ## EC2.2
@@ -84,6 +85,7 @@ The minimal flags required to resolve EC2.2 are as follows. This will execute in
 ```bash
 fsbp-fix EC2.2 -profile <PROFILE> -region <REGION> [OPTIONAL_FLAGS]
 ```
+
 <details>
   <summary>Details</summary>
 AWS Security Hub Control [EC2.2](https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-2) states that default security groups in VPCs should not allow any inbound or outbound traffic. VPCs set up recently are compliant by default, but older VPCs are not.
@@ -103,6 +105,7 @@ flowchart TB
     ruleBreak --> Nope --> break
 
 ```
+
 </details>
 
 <details>
@@ -114,6 +117,7 @@ ingress-inquisition takes the following flags:
 - **region**: _Required._ The region you want to search in.
 
 - **execute**: _Optional._ Takes no value. If present, it will ask the user to confirm, then delete the rules. Otherwise, it will just list the rules that would have been deleted.
+
 </details>
 
 <details>
@@ -124,6 +128,7 @@ command from the ingress-inquisitor subdirectory, without needing to build the b
 ```bash
 go run main.go EC2.2 -profile <PROFILE> -region <REGION> [OPTIONAL_FLAGS]
 ```
+
 </details>
 
 <details>

--- a/script/dash-lint.sh
+++ b/script/dash-lint.sh
@@ -11,7 +11,7 @@ function bad_delimiter_check() {
     FAILURES=$(grep -ril "$WRONG_NAME" "$ROOT_DIR")
 
     if [ -n "$FAILURES" ]; then
-        echo "$TOOL_NAME has a dash in it, and inconsistencies in the codebase can cause major problems, please correct the spelling." >&2
+        echo "$TOOL_NAME has a dash in it, not a '$DELIMITER'. Inconsistencies in the codebase can cause major problems, please correct the spelling." >&2
         printf "The following files contain the incorrect string '%s':\n\n" "$WRONG_NAME" >&2
         echo "$FAILURES" >&2
         exit 1;

--- a/script/dash-lint.sh
+++ b/script/dash-lint.sh
@@ -1,18 +1,26 @@
 #!/usr/bin/env bash
 
 TOOL_NAME=$1
-INCORRECT_NAME=$(echo "$TOOL_NAME" | tr -d -)
-
 CURRENT_FILE=$(basename "${BASH_SOURCE}")
 ROOT_DIR=$(git rev-parse --show-toplevel)
-BAD_NAMES=$(grep -ril "$INCORRECT_NAME" "$ROOT_DIR" --exclude "$CURRENT_FILE" --exclude-dir=".git")
 
-if [ -n "$BAD_NAMES" ]; then
-    echo "$TOOL_NAME has a dash in it, and inconsistencies in the codebase can cause major problems, please correct the spelling." >&2
-    printf "The following files contain the incorrect string '%s':\n\n" "$INCORRECT_NAME" >&2
-    echo "$BAD_NAMES" >&2
-    exit 1;
-else
-    echo "No files contain the name '$INCORRECT_NAME'."
-    exit 0;
-fi
+function bad_delimiter_check() {
+    DELIMITER=$1
+    # shellcheck disable=SC2116
+    WRONG_NAME=$(echo "${TOOL_NAME//-/$DELIMITER}")
+    echo "Checking for $WRONG_NAME in the codebase..."
+    FAILURES=$(grep -ril "$WRONG_NAME" "$ROOT_DIR" --exclude "$CURRENT_FILE" --exclude-dir=".git")
+
+    if [ -n "$FAILURES" ]; then
+        echo "$TOOL_NAME has a dash in it, and inconsistencies in the codebase can cause major problems, please correct the spelling." >&2
+        printf "The following files contain the incorrect string '%s':\n\n" "$WRONG_NAME" >&2
+        echo "$FAILURES" >&2
+        exit 1;
+    else
+        printf "No files contain the erroneous name: '%s'.\n\n" "$WRONG_NAME"
+    fi
+}
+
+bad_delimiter_check "_"
+bad_delimiter_check " "
+bad_delimiter_check ""

--- a/script/dash-lint.sh
+++ b/script/dash-lint.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 
 TOOL_NAME=$1
-CURRENT_FILE=$(basename "${BASH_SOURCE}")
 ROOT_DIR=$(git rev-parse --show-toplevel)
 
 function bad_delimiter_check() {
     DELIMITER=$1
-    # shellcheck disable=SC2116
+    # shellcheck disable=SC2116 # Without echo, WRONG_NAME will be empty
     WRONG_NAME=$(echo "${TOOL_NAME//-/$DELIMITER}")
     echo "Checking for $WRONG_NAME in the codebase..."
-    FAILURES=$(grep -ril "$WRONG_NAME" "$ROOT_DIR" --exclude "$CURRENT_FILE" --exclude-dir=".git")
+    FAILURES=$(grep -ril "$WRONG_NAME" "$ROOT_DIR")
 
     if [ -n "$FAILURES" ]; then
         echo "$TOOL_NAME has a dash in it, and inconsistencies in the codebase can cause major problems, please correct the spelling." >&2


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Tests for additional, common mistakes in spelling fsbp-fix
- Removes the requirement for exclusions in particular areas of the code, as we are no longer required to pass in the full bad string, just the delimiter we want to check for

## How to test

- CI should still pass.
- If you want to check the unhappy path, just type `fsbpfix` somewhere in the readme and run `./script/dash-lint.sh fsbp-fix`

## Images
### Happy path
<img width="400" alt="Screenshot 2024-10-24 at 08 28 29" src="https://github.com/user-attachments/assets/c1373ec9-8496-4487-8832-324af3c07425">

### Unhappy path
<img width="972" alt="Screenshot 2024-10-24 at 08 30 28" src="https://github.com/user-attachments/assets/70f09487-b921-4f63-a555-ef99938f7fd3">


