### PR TITLE
Introduce commit linting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,13 @@ jobs:
           APP: fsbp-fix
           GO_VERSION: ${{ env.GO_VERSION }}
 
+  commit-lint:
+    runs-on: ubuntu-latest
+    name: Run Commitlint
+    steps:
+      - name: Conventional Commitlint
+        uses: opensource-nepal/commitlint@02e7ff4f7f1e4b1f8e2955b114bfa9271f1c7c97 # v1.3.0
+
   enforce-dashes:
     name: Enforce dashes in project names
     runs-on: ubuntu-latest
@@ -55,7 +62,7 @@ jobs:
       contents: write
       packages: write
       issues: write
-    needs: [build-fsbp-fix, enforce-dashes]
+    needs: [build-fsbp-fix, commit-lint, enforce-dashes]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Enforces conventional commit spec on all PRs

## How to test

Branch off of this branch, add a non-conventional commit to the tree, push it, and run the action.


## How can we measure success?

Users are forced to use conventional commits, meaning releases can be correctly versioned

## What are the risks?

### Is this code safe?

I've inspected the critical paths for us, and couldn't see anything obviously sneaky going on. Pinning to a particular commit hash will stop the code changing under our feet.

### Will the underlying action be maintained? Is this dangerous?

opensource-nepal is quite a small org, and seems to be entirely dependent on volunteers, so it's possible this could go unmainainted for a while. I'm not super concerned about the security implications of this, for the following reasons:

- It's a pretty small app with [relatively few dependencies](https://github.com/opensource-nepal/commitlint/blob/02e7ff4f7f1e4b1f8e2955b114bfa9271f1c7c97/Pipfile). We could raise a PR against the repo ourselves if this was a concern
- In our CI process, it runs in a standalone job that has read-only permissions, so it can't modify our code.
- `commit-lint` is isolated from the build step, so the chances of interference at build time are low.

## Images
Example unhappy output from build 179:

<img width="519" alt="Screenshot 2024-10-24 at 10 24 35" src="https://github.com/user-attachments/assets/d825a243-4dc7-4fba-9e22-f8dc6c4b9ed0">

Example happy output from build 182:
<img width="297" alt="Screenshot 2024-10-24 at 10 29 17" src="https://github.com/user-attachments/assets/2b1ef502-c8db-49ef-8c0b-09283a6c3642">
