### PR TITLE
docs: Explain what EC2.2 is evaluating

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ go run main.go s3.8 -profile <PROFILE> -region <REGION> [OPTIONAL_FLAGS]
 
 </details>
 
-## EC2.2
+## EC2.2 - VPC default security groups should not allow inbound or outbound traffic
 
 ### Usage
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Earlier in this readme, we explain what [S3.8 is evaluating](https://github.com/guardian/fsbp-tools/blob/278cbaf605ac7ade92c777833a6b01fd62679d01/README.md?plain=1#L14). For consistency, and to save a few google searches, I've added a similar line to the EC2.2 section of the README

## How to test

No testing required.

## How can we measure success?

Users don't need to look up EC2.2 in the Security Hub documentation
