### PR TITLE
trigger a patch release when dependencies are updated

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -18,5 +18,13 @@
         ]
       }
     ]
-  ]
+  ],
+  "analyzeCommits": {
+    "releaseRules": [
+      {
+        "type": "chore(deps)",
+        "release": "patch"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are merging monthly version updates (and additional ones when security advisories are released), but not releasing new versions of the tool unless a human fixes a bug/adds a feature. This defeats the point of timely security updates. This change creates a patch release when a dependency update is merged, which can then be propagated to homebrew

## How can we measure success?

More frequent releases - better security for end users
