### PR TITLE
Rename LoadDefaultConfig, and reuse it

### DIFF
--- a/bucket-utils/bucketblocker.go
+++ b/bucket-utils/bucketblocker.go
@@ -11,12 +11,12 @@ import (
 )
 
 func FixS3_8(ctx context.Context, profile string, region string, bucketCount int, exclusions []string, execute bool) {
-	cfg, err := common.LoadDefaultConfig(ctx, profile, region)
+	cfg, err := common.Auth(ctx, profile, region)
 	if err != nil {
 		log.Fatalf("unable to load SDK config, %v", err)
 	}
 
-	accountId, err := common.GetAccountId(ctx, profile, region)
+	accountId, err := common.GetAccountId(ctx, cfg)
 	if err != nil {
 		log.Fatalf("Error getting account ID: %v", err)
 	}

--- a/bucket-utils/bucketblocker.go
+++ b/bucket-utils/bucketblocker.go
@@ -4,17 +4,14 @@ import (
 	"context"
 	"log"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/securityhub"
 	"github.com/guardian/fsbp-tools/fsbp-fix/common"
 )
 
-func FixS3_8(ctx context.Context, profile string, region string, bucketCount int, exclusions []string, execute bool) {
-	cfg, err := common.Auth(ctx, profile, region)
-	if err != nil {
-		log.Fatalf("unable to load SDK config, %v", err)
-	}
+func FixS3_8(ctx context.Context, cfg aws.Config, bucketCount int, exclusions []string, execute bool) {
 
 	accountId, err := common.GetAccountId(ctx, cfg)
 	if err != nil {
@@ -24,7 +21,7 @@ func FixS3_8(ctx context.Context, profile string, region string, bucketCount int
 	securityHubClient := securityhub.NewFromConfig(cfg)
 	s3Client := s3.NewFromConfig(cfg)
 	cfnClient := cloudformation.NewFromConfig(cfg)
-	bucketsToBlock, err := FindBucketsToBlock(ctx, securityHubClient, s3Client, cfnClient, int32(bucketCount), exclusions, accountId, region)
+	bucketsToBlock, err := FindBucketsToBlock(ctx, securityHubClient, s3Client, cfnClient, int32(bucketCount), exclusions, accountId, cfg.Region)
 	if err != nil {
 		log.Fatalf("Error working out which buckets need blocking: %v", err)
 	}

--- a/common/aws.go
+++ b/common/aws.go
@@ -20,7 +20,7 @@ func validateCredentials(ctx context.Context, stsClient *sts.Client, profile str
 	return resp, nil
 }
 
-func LoadDefaultConfig(ctx context.Context, profile string, region string) (aws.Config, error) {
+func Auth(ctx context.Context, profile string, region string) (aws.Config, error) {
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithSharedConfigProfile(profile), config.WithDefaultRegion(region))
 	if err != nil {
 		fmt.Println("Error loading configuration")
@@ -36,15 +36,7 @@ func LoadDefaultConfig(ctx context.Context, profile string, region string) (aws.
 	return cfg, nil
 }
 
-func GetAccountId(ctx context.Context, profile string, region string) (string, error) {
-	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithSharedConfigProfile(profile),
-		config.WithRegion(region),
-	)
-	if err != nil {
-		return "", fmt.Errorf("error loading config: %w", err)
-	}
-
+func GetAccountId(ctx context.Context, cfg aws.Config) (string, error) {
 	stsClient := sts.NewFromConfig(cfg)
 	resp, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	bucketutils "github.com/guardian/fsbp-tools/fsbp-fix/bucket-utils"
+	"github.com/guardian/fsbp-tools/fsbp-fix/common"
 	vpcutils "github.com/guardian/fsbp-tools/fsbp-fix/vpc-utils"
 )
 
@@ -59,7 +60,9 @@ func main() {
 			fmt.Printf("Parsing exclusions")
 			exclusionsSlice = bucketutils.SplitAndTrim(*exclusions)
 		}
-		bucketutils.FixS3_8(ctx, *profile, *region, *bucketCount, exclusionsSlice, *execute)
+
+		cfg, _ := common.Auth(ctx, *profile, *region)
+		bucketutils.FixS3_8(ctx, cfg, *bucketCount, exclusionsSlice, *execute)
 
 	case "ec2.2":
 		execute := fixEc2_2.Bool("execute", false, "Execute the block operation")
@@ -76,7 +79,8 @@ func main() {
 			log.Fatal("Please provide a region")
 		}
 
-		vpcutils.FixEc2_2(ctx, *profile, *region, *execute)
+		cfg, _ := common.Auth(ctx, *profile, *region)
+		vpcutils.FixEc2_2(ctx, cfg, *execute)
 
 	default:
 		fmt.Println("expected 's3.8' or 'ec2.2' subcommands")

--- a/vpc-utils/ingressinquisition.go
+++ b/vpc-utils/ingressinquisition.go
@@ -12,7 +12,7 @@ import (
 
 func FixEc2_2(ctx context.Context, profile string, region string, execute bool) { //TODO does this need to be a pointer?
 
-	cfg, err := common.LoadDefaultConfig(ctx, profile, region)
+	cfg, err := common.Auth(ctx, profile, region)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
@@ -20,7 +20,7 @@ func FixEc2_2(ctx context.Context, profile string, region string, execute bool) 
 	ec2Client := ec2.NewFromConfig(cfg)
 	securityHubClient := securityhub.NewFromConfig(cfg)
 
-	accountId, err := common.GetAccountId(ctx, profile, region)
+	accountId, err := common.GetAccountId(ctx, cfg)
 	if err != nil {
 		log.Fatalf("Error getting account ID: %v", err)
 	}

--- a/vpc-utils/ingressinquisition.go
+++ b/vpc-utils/ingressinquisition.go
@@ -5,17 +5,13 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/securityhub"
 	"github.com/guardian/fsbp-tools/fsbp-fix/common"
 )
 
-func FixEc2_2(ctx context.Context, profile string, region string, execute bool) { //TODO does this need to be a pointer?
-
-	cfg, err := common.Auth(ctx, profile, region)
-	if err != nil {
-		log.Fatalf("%v", err)
-	}
+func FixEc2_2(ctx context.Context, cfg aws.Config, execute bool) {
 
 	ec2Client := ec2.NewFromConfig(cfg)
 	securityHubClient := securityhub.NewFromConfig(cfg)
@@ -25,7 +21,7 @@ func FixEc2_2(ctx context.Context, profile string, region string, execute bool) 
 		log.Fatalf("Error getting account ID: %v", err)
 	}
 
-	securityGroupRuleDetails, err := FindUnusedSecurityGroupRules(ctx, ec2Client, securityHubClient, accountId, region)
+	securityGroupRuleDetails, err := FindUnusedSecurityGroupRules(ctx, ec2Client, securityHubClient, accountId, cfg.Region)
 
 	if err != nil {
 		log.Fatalf("Error finding unused security group rules: %v", err)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

AWS already has a function called `GetDefaultConfig`. I've renamed our implementation `Auth`, to avoid confusion, and we are now using it in a consistent way, only authenticating once per run. One of the params passed to `Auth` is region, and when we add multi-region support for this tool, it will make it easier to ensure that we are not switching regions by accident by reauthenticating partway through an operation (which was happening in `GetAccountId`).

## How to test

Run the tool locally to verify auth is working

## How can we measure success?

Easier to read code, fewer auth calls to aws
