### PR TITLE
if one region fails, continue with the others

### DIFF
--- a/common/io.go
+++ b/common/io.go
@@ -25,3 +25,9 @@ func ExitOnError(err error, msg string) {
 		log.Fatalf("%s: %v", msg, err)
 	}
 }
+
+func WarnOnError(err error, msg string) {
+	if err != nil {
+		log.Printf("Warning: %s: %v", msg, err)
+	}
+}

--- a/vpc-utils/ingressinquisition.go
+++ b/vpc-utils/ingressinquisition.go
@@ -16,7 +16,7 @@ import (
 func findEc2_2(ch chan<- SecurityGroupRuleDetails, ctx context.Context, cfg aws.Config, ec2Client *ec2.Client, accountId string) {
 	securityHubClient := securityhub.NewFromConfig(cfg)
 	res, err := FindUnusedSecurityGroupRules(ctx, ec2Client, securityHubClient, accountId, cfg.Region)
-	common.ExitOnError(err, "Failed to find unused security group rules in region "+cfg.Region)
+	common.WarnOnError(err, "Failed to find unused security group rules in region "+cfg.Region)
 	if len(res.Groups) > 0 {
 		ch <- res
 	} else {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

SecurityHub can only be deployed into accounts that are enabled by the delegated administrator. If a member account has enabled additional opt-in regions, the tool will fail as it won't be able to detect a Hub in that region, and we will not be able to delete any group rules. This change turns that error into a warning, so we can still run in other regions

## How to test

I've run the tool in one of the accounts that has this edge case, and we are no longer seeing failures
